### PR TITLE
Using Block Display instead of hidden overflow to avoid cropping

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
   <title>Seedling Drop v2</title>
   <style>
     body {
-      overflow: hidden;
       width: 100vw;
       height: 100vh;
       background: transparent;
@@ -18,6 +17,10 @@
       padding: 0;
     }
 
+    canvas {
+      display: block;
+    }
+    
     #container {
       width: 100%;
       height: 100%;


### PR DESCRIPTION
Issue: Canvas does not fit the window / Scroll Bar Appearing

Reason: By default, the canvas style is `display: inline` (!) though it is said to be a "block" element

Previous fix: 
```css
body {
  overflow: hidden;
}
```

new:
```css
canvas: {
  display: block;
}
```

To overcome the issue, the p5.js web editor's default styles are:  
```css
html, body {
  margin: 0;
  padding: 0;
}
canvas {
  display: block;
}
```